### PR TITLE
Add citation section to README files for OmniMoE

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,4 +103,16 @@ See [LICENSE](LICENSE).
 
 ## Citation
 
-paper is coming soon.
+If you find this work useful, please consider citing:
+
+```bibtex
+@misc{shi2026omnimoe,
+      title={OmniMoE: An Efficient MoE by Orchestrating Atomic Experts at Scale}, 
+      author={Jingze Shi and Zhangyang Peng and Yizhang Zhu and Yifan Wu and Guang Liu and Yuyu Luo},
+      year={2026},
+      eprint={2602.05711},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2602.05711}, 
+}
+```

--- a/README_zh.md
+++ b/README_zh.md
@@ -103,4 +103,16 @@ pytest tests/test_expert.py -s
 
 ## Citation
 
-paper is coming soon.
+如果你认为 OmniMoE 对你的研究有帮助, 请考虑引用:
+
+```bibtex
+@misc{shi2026omnimoe,
+      title={OmniMoE: An Efficient MoE by Orchestrating Atomic Experts at Scale}, 
+      author={Jingze Shi and Zhangyang Peng and Yizhang Zhu and Yifan Wu and Guang Liu and Yuyu Luo},
+      year={2026},
+      eprint={2602.05711},
+      archivePrefix={arXiv},
+      primaryClass={cs.CL},
+      url={https://arxiv.org/abs/2602.05711}, 
+}
+```


### PR DESCRIPTION
Include a citation section in the README files to encourage users to cite the work if it proves useful. The citation is provided in both English and Chinese for accessibility.